### PR TITLE
Disable mock markets when offline

### DIFF
--- a/src/lib/components/MarketSelectorButton.svelte
+++ b/src/lib/components/MarketSelectorButton.svelte
@@ -6,8 +6,6 @@
   import type { MarketData } from '$lib/services/offers';
   import MarketSelector from './MarketSelector.svelte';
 
-  export let currentPrice = 0;
-  export let priceChange24h = 0;
 
   const dispatch = createEventDispatcher<{
     marketChange: MarketData;
@@ -50,9 +48,8 @@
     <ChevronDown size={16} class="chevron" />
   </button>
 
-  <MarketSelector 
+  <MarketSelector
     bind:isOpen={showMarketSelector}
-    selectedMarket={$selectedMarket}
     on:select={handleMarketSelect}
   />
 </div>

--- a/src/lib/components/TradingPanel.svelte
+++ b/src/lib/components/TradingPanel.svelte
@@ -3,7 +3,7 @@
   import { blockchain } from '$lib/stores/blockchain';
   import { positions } from '$lib/stores/positions';
   import { Zap, TrendingUp } from 'lucide-svelte';
-  import { getMarketData, getMockMarketData, type MarketData } from '$lib/services/offers';
+  import { getMarketData, type MarketData } from '$lib/services/offers';
   import { selectedMarket as selectedMarketStore } from '$lib/stores/markets';
   import { onMount } from 'svelte';
   
@@ -20,12 +20,9 @@
   async function loadMarkets() {
     try {
       markets = await getMarketData();
-      if (markets.length === 0) {
-        markets = getMockMarketData();
-      }
     } catch (error) {
       console.error('Failed to load markets:', error);
-      markets = getMockMarketData();
+      markets = [];
     } finally {
       loading = false;
     }

--- a/src/lib/services/offers.ts
+++ b/src/lib/services/offers.ts
@@ -140,8 +140,8 @@ export async function getMarketData(): Promise<MarketData[]> {
     return offers.map(transformOfferToMarket);
   } catch (error) {
     console.error('Failed to get market data:', error);
-    // Return mock data as fallback
-    return getMockMarketData();
+    // Return empty array if network request fails
+    return [];
   }
 }
 

--- a/src/lib/services/wallet.ts
+++ b/src/lib/services/wallet.ts
@@ -4,6 +4,8 @@ import { auth } from '$lib/stores/auth';
 import { browser } from '$app/environment';
 import type { Connector } from '@wagmi/core';
 
+type ChainId = (typeof config.chains)[number]['id'];
+
 export interface WalletProfile {
   id: string;
   walletAddress: string;
@@ -101,7 +103,7 @@ export function getCurrentAccount() {
 }
 
 // Switch network
-export async function switchNetwork(chainId: number): Promise<void> {
+export async function switchNetwork(chainId: ChainId): Promise<void> {
   try {
     await switchChain(config, { chainId });
   } catch (error) {

--- a/src/lib/stores/markets.ts
+++ b/src/lib/stores/markets.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
-import { getMarketData, getMockMarketData, type MarketData } from '$lib/services/offers';
+import { getMarketData, type MarketData } from '$lib/services/offers';
 
 // Create the store with initial state
 export const markets = writable<MarketData[]>([]);
@@ -15,28 +15,26 @@ export async function loadMarkets() {
   loading.set(true);
   try {
     let marketData = await getMarketData();
-    if (marketData.length === 0) {
-      marketData = getMockMarketData();
-    }
     markets.set(marketData);
     
     // Update current market
-    selectedMarket.subscribe(symbol => {
-      const market = marketData.find(m => m.symbol === symbol) || marketData[0];
-      if (market) {
-        currentMarket.set(market);
-        if (!marketData.find(m => m.symbol === symbol)) {
-          selectedMarket.set(market.symbol);
+    if (marketData.length > 0) {
+      selectedMarket.subscribe(symbol => {
+        const market = marketData.find(m => m.symbol === symbol) || marketData[0];
+        if (market) {
+          currentMarket.set(market);
+          if (!marketData.find(m => m.symbol === symbol)) {
+            selectedMarket.set(market.symbol);
+          }
         }
-      }
-    });
+      });
+    } else {
+      currentMarket.set(null);
+    }
   } catch (error) {
     console.error('Failed to load markets:', error);
-    const mockData = getMockMarketData();
-    markets.set(mockData);
-    const market = mockData[0];
-    currentMarket.set(market);
-    selectedMarket.set(market.symbol);
+    markets.set([]);
+    currentMarket.set(null);
   } finally {
     loading.set(false);
   }

--- a/src/routes/trade/+page.svelte
+++ b/src/routes/trade/+page.svelte
@@ -48,11 +48,7 @@
     <div class="lg:col-span-2 space-y-6">
       <div class="card">
         <div class="trade-header">
-          <MarketSelectorButton 
-            currentPrice={currentPrice}
-            priceChange24h={priceChange24h}
-            on:marketChange={handleMarketChange}
-          />
+          <MarketSelectorButton on:marketChange={handleMarketChange} />
         </div>
         
         <div class="grid grid-cols-2 gap-4 mb-6">


### PR DESCRIPTION
## Summary
- return an empty array from `getMarketData` if fetching fails
- remove mock markets fallback from stores and components
- fix pnpm check errors

## Testing
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed fallback to mock market data across the app. If market data cannot be loaded, relevant displays will now show empty states instead of mock information.
	- Simplified the Market Selector button and its usage by removing unnecessary props.
	- Improved type safety for network switching by restricting chain IDs to configured values.

- **Bug Fixes**
	- Enhanced error handling for market data loading, ensuring the app clears data on failure rather than showing outdated or mock content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->