### PR TITLE
Implement open long tx and position table

### DIFF
--- a/src/lib/components/PositionsTable.svelte
+++ b/src/lib/components/PositionsTable.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { positions } from '$lib/stores/positions';
+  import { closePosition } from '$lib/services/trading';
+  import type { Position } from '$lib/stores/positions';
+
+  let closing: Record<string, boolean> = {};
+
+  async function handleClose(id: string) {
+    closing[id] = true;
+    try {
+      await closePosition(id);
+      positions.updatePosition(id, { status: 'closed' });
+    } catch (e) {
+      console.error('Failed to close position:', e);
+    } finally {
+      closing[id] = false;
+    }
+  }
+</script>
+
+<table class="min-w-full text-sm">
+  <thead class="bg-white/5">
+    <tr>
+      <th class="px-3 py-2 text-left">Asset</th>
+      <th class="px-3 py-2 text-right">Size</th>
+      <th class="px-3 py-2 text-right">Entry</th>
+      <th class="px-3 py-2 text-right">Price</th>
+      <th class="px-3 py-2 text-right">Lev</th>
+      <th class="px-3 py-2 text-right">PnL</th>
+      <th class="px-3 py-2 text-right"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {#each $positions.positions.filter(p => p.status === 'open') as p (p.id)}
+      <tr class="border-b border-white/10">
+        <td class="px-3 py-2 font-mono">{p.asset}</td>
+        <td class="px-3 py-2 text-right font-mono">{p.size.toFixed(4)}</td>
+        <td class="px-3 py-2 text-right font-mono">${p.entryPrice.toFixed(2)}</td>
+        <td class="px-3 py-2 text-right font-mono">${p.currentPrice.toFixed(2)}</td>
+        <td class="px-3 py-2 text-right font-mono">{p.leverage}x</td>
+        <td class="px-3 py-2 text-right font-mono {p.pnl >= 0 ? 'text-green-400' : 'text-red-400'}">
+          {p.pnl >= 0 ? '+' : ''}{p.pnl.toFixed(2)}
+        </td>
+        <td class="px-3 py-2 text-right">
+          <button class="btn-secondary text-xs" disabled={closing[p.id]} on:click={() => handleClose(p.id)}>
+            {closing[p.id] ? 'Closing...' : 'Close'}
+          </button>
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>
+
+<style>
+  table {
+    @apply w-full text-sm;
+  }
+</style>

--- a/src/lib/components/TradingPanel.svelte
+++ b/src/lib/components/TradingPanel.svelte
@@ -7,12 +7,45 @@
   import { selectedMarket as selectedMarketStore } from '$lib/stores/markets';
   import { openLongPosition } from '$lib/services/trading';
   import { onMount } from 'svelte';
+  import { formatPrice } from '$lib/services/birdeye';
+  import { switchNetwork } from '$lib/services/wallet';
+  import { getAccount } from '@wagmi/core';
+  import { config } from '$lib/config/wagmi';
+  import { bsc } from '@wagmi/core/chains';
   
   let collateral = 0.1;
   let leverage = 1.2;
   let isOpening = false;
   let markets: MarketData[] = [];
   let loading = true;
+  let switchingNetwork = false;
+
+  // Handler to format collateral input to 5 decimal places
+  function handleCollateralInput(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const value = input.value;
+    
+    // Allow empty input and decimal point for better UX
+    if (!value || value.endsWith('.') || value.endsWith('.0') || value.endsWith('.00') || 
+        value.endsWith('.000') || value.endsWith('.0000') || value.endsWith('.00000')) {
+      collateral = parseFloat(value) || 0;
+      return;
+    }
+
+    // Only format if we have a complete number
+    const parsed = parseFloat(value);
+    if (!isNaN(parsed)) {
+      // Split the number into integer and decimal parts
+      const parts = value.split('.');
+      if (parts.length === 2 && parts[1].length > 5) {
+        // Only truncate if we have more than 5 decimal places
+        collateral = Math.round(parsed * 100000) / 100000;
+        input.value = collateral.toString();
+      } else {
+        collateral = parsed;
+      }
+    }
+  }
 
   onMount(async () => {
     await loadMarkets();
@@ -27,6 +60,24 @@
     } finally {
       loading = false;
     }
+  }
+
+  async function ensureCorrectNetwork(): Promise<boolean> {
+    const account = getAccount(config);
+    if (account.chainId !== bsc.id) {
+      try {
+        switchingNetwork = true;
+        await switchNetwork(bsc.id);
+        return true;
+      } catch (error) {
+        console.error('Failed to switch network:', error);
+        alert('Please switch to BSC network in your wallet');
+        return false;
+      } finally {
+        switchingNetwork = false;
+      }
+    }
+    return true;
   }
 
   $: currentMarket = markets.find(m => m.symbol === $selectedMarketStore) || markets[0];
@@ -44,6 +95,16 @@
     
     if (collateral <= 0) {
       alert('Please enter a valid collateral amount');
+      return;
+    }
+
+    if (!currentMarket) {
+      alert('Market data not available');
+      return;
+    }
+
+    // Ensure we're on the correct network
+    if (!(await ensureCorrectNetwork())) {
       return;
     }
     
@@ -103,14 +164,15 @@
   <div class="space-y-6">
     <div>
       <label for="collateral-input" class="block text-sm font-medium text-gray-300 mb-2">
-        Collateral ({tokenSymbol})
+        Collateral (BNB)
       </label>
       <input
         id="collateral-input"
         type="number"
         bind:value={collateral}
+        on:input={handleCollateralInput}
         min="0.001"
-        step="0.001"
+        step="0.00001"
         class="input-field"
         placeholder="0.1"
       />
@@ -167,11 +229,11 @@
       </div>
       <div class="flex justify-between text-sm">
         <span class="text-gray-400">Entry Price</span>
-        <span class="font-mono">${currentPrice.toFixed(4)}</span>
+        <span class="font-mono">${formatPrice(currentPrice)}</span>
       </div>
       <div class="flex justify-between text-sm">
         <span class="text-gray-400">Liquidation Price</span>
-        <span class="font-mono text-red-400">${liquidationPrice.toFixed(4)}</span>
+        <span class="font-mono text-red-400">${formatPrice(liquidationPrice)}</span>
       </div>
       <div class="flex justify-between text-sm">
         <span class="text-gray-400">Est. Fees</span>
@@ -182,11 +244,14 @@
     <button
       class="btn-primary w-full"
       on:click={openPosition}
-      disabled={!$isAuthenticated || isOpening || collateral <= 0}
+      disabled={!$isAuthenticated || isOpening || collateral <= 0 || switchingNetwork}
     >
       {#if isOpening}
         <Zap class="w-4 h-4 animate-pulse" />
         Opening Position...
+      {:else if switchingNetwork}
+        <Zap class="w-4 h-4 animate-pulse" />
+        Switching Network...
       {:else}
         <TrendingUp class="w-4 h-4" />
         Open Long Position

--- a/src/lib/services/offers.ts
+++ b/src/lib/services/offers.ts
@@ -54,7 +54,7 @@ export interface MarketData {
   priceVsQuote: string;
 }
 
-const API_BASE_URL = 'http://localhost:3000';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://ng-api.lavarave.wtf/api/sdk/v1.0';
 const API_KEY = import.meta.env.VITE_LAVARAGE_API_KEY || 'your_api_key_here';
 
 export async function fetchBscOffers(): Promise<OfferEvmModel[]> {
@@ -63,7 +63,7 @@ export async function fetchBscOffers(): Promise<OfferEvmModel[]> {
   }
 
   try {
-    const response = await fetch(`${API_BASE_URL}/api/sdk/v1.0/offers/bsc`, {
+    const response = await fetch(`${API_BASE_URL}/offers/bsc`, {
       method: 'GET',
       headers: {
         'x-api-key': API_KEY,

--- a/src/lib/services/trading.ts
+++ b/src/lib/services/trading.ts
@@ -1,40 +1,81 @@
 import type { Position } from '$lib/stores/positions';
 import type { SupportedBlockchain } from '$lib/stores/blockchain';
+import { getCurrentAccount } from '$lib/services/wallet';
+import { config } from '$lib/config/wagmi';
+import { sendTransaction, waitForTransactionReceipt } from '@wagmi/core';
 
 export interface OpenPositionParams {
   blockchain: SupportedBlockchain;
   asset: string;
   collateral: number;
   leverage: number;
+  collateralAddress: string;
+  quoteToken: string;
+  slippage?: number;
+  partnerFeeRecipient?: string;
 }
 
-// Mock trading service
-// In production, integrate with smart contracts or trading API
-export async function openLongPosition(params: OpenPositionParams): Promise<Position> {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
-  const entryPrice = 3542.18; // Mock price
-  const positionSize = params.collateral * params.leverage;
-  
-  const position: Position = {
-    id: 'pos_' + Math.random().toString(36).substr(2, 9),
-    blockchain: params.blockchain,
-    asset: params.asset,
-    type: 'long',
-    entryPrice,
-    currentPrice: entryPrice,
-    size: positionSize,
+interface OpenBscPositionDto {
+  collateralAddress: string;
+  margin: number;
+  leverage: number;
+  quoteToken: string;
+  userPubKey: string;
+  slippage?: number;
+  partnerFeeRecipient?: string;
+}
+
+interface TransactionBscModel {
+  data: string;
+  to: string;
+  gasLimit?: string;
+  gasPrice?: string;
+  txHash?: string;
+}
+
+const API_URL = import.meta.env.VITE_API_URL || 'https://api.lavarage.com/api/sdk/v1.0';
+const API_KEY = import.meta.env.VITE_API_KEY || '';
+
+export async function openLongPosition(params: OpenPositionParams): Promise<string> {
+  const account = getCurrentAccount();
+  if (!account.address) throw new Error('Wallet not connected');
+
+  const body: OpenBscPositionDto = {
+    collateralAddress: params.collateralAddress,
+    margin: params.collateral,
     leverage: params.leverage,
-    collateral: params.collateral,
-    pnl: 0,
-    pnlPercentage: 0,
-    liquidationPrice: calculateLiquidationPrice(entryPrice, params.leverage),
-    timestamp: Date.now(),
-    status: 'open'
+    quoteToken: params.quoteToken,
+    userPubKey: account.address,
+    slippage: params.slippage ?? 500,
+    partnerFeeRecipient: params.partnerFeeRecipient,
   };
-  
-  return position;
+
+  const res = await fetch(`${API_URL}/positions/bsc/open`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': API_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to get transaction data');
+  }
+
+  const tx: TransactionBscModel = await res.json();
+
+  const hash = await sendTransaction(config, {
+    account: account.address,
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
+    gas: tx.gasLimit ? BigInt(tx.gasLimit) : undefined,
+    gasPrice: tx.gasPrice ? BigInt(tx.gasPrice) : undefined,
+  });
+
+  await waitForTransactionReceipt(config, { hash });
+
+  return hash;
 }
 
 export async function closePosition(positionId: string): Promise<void> {

--- a/src/lib/services/trading.ts
+++ b/src/lib/services/trading.ts
@@ -17,7 +17,7 @@ export interface OpenPositionParams {
 
 interface OpenBscPositionDto {
   collateralAddress: string;
-  margin: number;
+  margin: string;
   leverage: number;
   quoteToken: string;
   userPubKey: string;
@@ -33,7 +33,7 @@ interface TransactionBscModel {
   txHash?: string;
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://api.lavarage.com/api/sdk/v1.0';
+const API_URL = import.meta.env.VITE_API_URL || 'https://ng-api.lavarave.wtf/api/sdk/v1.0';
 const API_KEY = import.meta.env.VITE_API_KEY || '';
 
 export async function openLongPosition(params: OpenPositionParams): Promise<string> {
@@ -42,7 +42,7 @@ export async function openLongPosition(params: OpenPositionParams): Promise<stri
 
   const body: OpenBscPositionDto = {
     collateralAddress: params.collateralAddress,
-    margin: params.collateral,
+    margin: (BigInt(Math.round(params.collateral * 1000000)) * BigInt(1000000000000)).toString(),
     leverage: params.leverage,
     quoteToken: params.quoteToken,
     userPubKey: account.address,

--- a/src/routes/trade/+page.svelte
+++ b/src/routes/trade/+page.svelte
@@ -2,6 +2,7 @@
   import TradingPanel from '$lib/components/TradingPanel.svelte';
   import BirdeyeChart from '$lib/components/BirdeyeChart.svelte';
   import MarketSelectorButton from '$lib/components/MarketSelectorButton.svelte';
+  import PositionsTable from '$lib/components/PositionsTable.svelte';
   import { isAuthenticated } from '$lib/stores/auth';
   import { openPositions } from '$lib/stores/positions';
   import { blockchain } from '$lib/stores/blockchain';
@@ -124,7 +125,13 @@
     
     <div class="space-y-6">
       <TradingPanel />
-      
+
+      {#if $openPositions.length > 0}
+        <div class="card">
+          <PositionsTable />
+        </div>
+      {/if}
+
       <div class="card space-y-3">
         <h3 class="text-sm font-semibold text-gray-400 flex items-center gap-2">
           <Shield class="w-4 h-4" />


### PR DESCRIPTION
## Summary
- integrate open position endpoint and submit tx through Wagmi
- add table component to manage open positions
- show positions table on trade page

## Testing
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a table displaying open trading positions, including asset details, size, entry/current price, leverage, and PnL.
  - Added the ability to close open positions directly from the table with real-time status updates.
  - The trade page now displays the positions table when open positions exist.

- **Improvements**
  - Opening a new position now interacts with the blockchain and displays the transaction hash for confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->