### PR TITLE
Fetch positions from API and show table

### DIFF
--- a/src/lib/components/PositionsTable.svelte
+++ b/src/lib/components/PositionsTable.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { positions, openPositions } from '$lib/stores/positions';
+  import { closePosition } from '$lib/services/trading';
+  import type { Position } from '$lib/stores/positions';
+
+  let closing: Record<string, boolean> = {};
+
+  async function handleClose(id: string) {
+    closing[id] = true;
+    try {
+      await closePosition(id);
+      positions.updatePosition(id, { status: 'closed' });
+    } catch (e) {
+      console.error('Failed to close position:', e);
+    } finally {
+      closing[id] = false;
+    }
+  }
+</script>
+
+<table class="min-w-full text-sm">
+  <thead class="bg-white/5">
+    <tr>
+      <th class="px-3 py-2 text-left">Asset</th>
+      <th class="px-3 py-2 text-right">Size</th>
+      <th class="px-3 py-2 text-right">Entry</th>
+      <th class="px-3 py-2 text-right">Price</th>
+      <th class="px-3 py-2 text-right">Lev</th>
+      <th class="px-3 py-2 text-right">PnL</th>
+      <th class="px-3 py-2 text-right"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {#if $openPositions.length === 0}
+      <tr>
+        <td colspan="7" class="py-4 text-center text-gray-400">No positions yet</td>
+      </tr>
+    {:else}
+      {#each $openPositions as p (p.id)}
+        <tr class="border-b border-white/10">
+          <td class="px-3 py-2 font-mono">{p.asset}</td>
+          <td class="px-3 py-2 text-right font-mono">{p.size.toFixed(4)}</td>
+          <td class="px-3 py-2 text-right font-mono">${p.entryPrice.toFixed(2)}</td>
+          <td class="px-3 py-2 text-right font-mono">${p.currentPrice.toFixed(2)}</td>
+          <td class="px-3 py-2 text-right font-mono">{p.leverage}x</td>
+        <td class="px-3 py-2 text-right font-mono {p.pnl >= 0 ? 'text-green-400' : 'text-red-400'}">
+          {p.pnl >= 0 ? '+' : ''}{p.pnl.toFixed(2)}
+        </td>
+        <td class="px-3 py-2 text-right">
+          <button class="btn-secondary text-xs" disabled={closing[p.id]} on:click={() => handleClose(p.id)}>
+            {closing[p.id] ? 'Closing...' : 'Close'}
+          </button>
+        </td>
+        </tr>
+      {/each}
+    {/if}
+  </tbody>
+</table>
+
+<style>
+  table {
+    @apply w-full text-sm;
+  }
+</style>

--- a/src/lib/services/trading.ts
+++ b/src/lib/services/trading.ts
@@ -1,40 +1,147 @@
 import type { Position } from '$lib/stores/positions';
 import type { SupportedBlockchain } from '$lib/stores/blockchain';
+import { getCurrentAccount } from '$lib/services/wallet';
+import { config } from '$lib/config/wagmi';
+import { sendTransaction, waitForTransactionReceipt } from '@wagmi/core';
 
 export interface OpenPositionParams {
   blockchain: SupportedBlockchain;
   asset: string;
   collateral: number;
   leverage: number;
+  collateralAddress: string;
+  quoteToken: string;
+  slippage?: number;
+  partnerFeeRecipient?: string;
 }
 
-// Mock trading service
-// In production, integrate with smart contracts or trading API
-export async function openLongPosition(params: OpenPositionParams): Promise<Position> {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
-  const entryPrice = 3542.18; // Mock price
-  const positionSize = params.collateral * params.leverage;
-  
-  const position: Position = {
-    id: 'pos_' + Math.random().toString(36).substr(2, 9),
-    blockchain: params.blockchain,
-    asset: params.asset,
+interface OpenBscPositionDto {
+  collateralAddress: string;
+  margin: number;
+  leverage: number;
+  quoteToken: string;
+  userPubKey: string;
+  slippage?: number;
+  partnerFeeRecipient?: string;
+}
+
+interface TransactionBscModel {
+  data: string;
+  to: string;
+  gasLimit?: string;
+  gasPrice?: string;
+  txHash?: string;
+}
+
+const API_URL = import.meta.env.VITE_API_URL || 'https://api.lavarage.com/api/sdk/v1.0';
+const API_KEY = import.meta.env.VITE_API_KEY || '';
+
+export async function openLongPosition(params: OpenPositionParams): Promise<string> {
+  const account = getCurrentAccount();
+  if (!account.address) throw new Error('Wallet not connected');
+
+  const body: OpenBscPositionDto = {
+    collateralAddress: params.collateralAddress,
+    margin: params.collateral,
+    leverage: params.leverage,
+    quoteToken: params.quoteToken,
+    userPubKey: account.address,
+    slippage: params.slippage ?? 500,
+    partnerFeeRecipient: params.partnerFeeRecipient,
+  };
+
+  const res = await fetch(`${API_URL}/positions/bsc/open`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': API_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to get transaction data');
+  }
+
+  const tx: TransactionBscModel = await res.json();
+
+  const hash = await sendTransaction(config, {
+    account: account.address,
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
+    gas: tx.gasLimit ? BigInt(tx.gasLimit) : undefined,
+    gasPrice: tx.gasPrice ? BigInt(tx.gasPrice) : undefined,
+  });
+
+  await waitForTransactionReceipt(config, { hash });
+
+  return hash;
+}
+
+function mapPosition(raw: any): Position {
+  const collateralSymbol =
+    raw.collateralToken?.symbol || raw.offer?.collateralToken?.symbol || 'UNKNOWN';
+  const quoteSymbol =
+    typeof raw.quoteToken === 'string'
+      ? raw.quoteToken
+      : raw.quoteToken?.symbol || raw.offer?.quoteToken?.symbol || 'UNKNOWN';
+
+  const entryPrice = Number(raw.entryPrice ?? 0);
+  const currentPrice = Number(raw.currentPrice ?? entryPrice);
+  const size = Number(raw.currentPositionBase ?? raw.initialPositionBase ?? 0);
+  const collateral = Number(raw.initialMarginQuote ?? raw.collateralAmount ?? 0);
+  const pnl = (currentPrice - entryPrice) * size;
+  const pnlPercentage = collateral ? (pnl / collateral) * 100 : 0;
+
+  let status: Position['status'] = 'open';
+  if (raw.status && typeof raw.status === 'string') {
+    if (raw.status.includes('liquidated')) status = 'liquidated';
+    else if (raw.status.includes('closed') || raw.status.includes('sold')) status = 'closed';
+  }
+
+  return {
+    id: raw.positionAddress || raw.publicKey || crypto.randomUUID(),
+    blockchain: 'bsc',
+    asset: `${collateralSymbol}-${quoteSymbol}`,
     type: 'long',
     entryPrice,
-    currentPrice: entryPrice,
-    size: positionSize,
-    leverage: params.leverage,
-    collateral: params.collateral,
-    pnl: 0,
-    pnlPercentage: 0,
-    liquidationPrice: calculateLiquidationPrice(entryPrice, params.leverage),
-    timestamp: Date.now(),
-    status: 'open'
+    currentPrice,
+    size,
+    leverage: Number(raw.currentLtv ?? raw.leverage ?? 1),
+    collateral,
+    pnl,
+    pnlPercentage,
+    liquidationPrice: Number(raw.liquidationPrice ?? 0),
+    timestamp: raw.openTimestamp
+      ? Date.parse(raw.openTimestamp)
+      : Date.now(),
+    status,
   };
-  
-  return position;
+}
+
+export async function fetchPositions(
+  userAddress: string,
+  status: 'open' | 'closed' | 'liquidated' | 'all' = 'open'
+): Promise<Position[]> {
+  const url = new URL(`${API_URL}/positions/evm`);
+  url.searchParams.set('status', status);
+  if (userAddress) url.searchParams.set('userAddress', userAddress);
+
+  const res = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      'x-api-key': API_KEY,
+      referer: typeof window !== 'undefined' ? window.location.origin : '',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch positions');
+  }
+
+  const data = await res.json();
+  if (!Array.isArray(data)) return [];
+  return data.map(mapPosition);
 }
 
 export async function closePosition(positionId: string): Promise<void> {

--- a/src/lib/stores/positions.ts
+++ b/src/lib/stores/positions.ts
@@ -53,6 +53,12 @@ function createPositionsStore() {
         positions: state.positions.filter(p => p.id !== id)
       }));
     },
+    setPositions: (items: Position[]) => {
+      update(state => ({
+        ...state,
+        positions: items
+      }));
+    },
     setLoading: (loading: boolean) => {
       update(state => ({ ...state, loading }));
     },

--- a/src/routes/trade/+page.svelte
+++ b/src/routes/trade/+page.svelte
@@ -2,8 +2,10 @@
   import TradingPanel from '$lib/components/TradingPanel.svelte';
   import BirdeyeChart from '$lib/components/BirdeyeChart.svelte';
   import MarketSelectorButton from '$lib/components/MarketSelectorButton.svelte';
-  import { isAuthenticated } from '$lib/stores/auth';
-  import { openPositions } from '$lib/stores/positions';
+  import PositionsTable from '$lib/components/PositionsTable.svelte';
+  import { isAuthenticated, walletAddress } from '$lib/stores/auth';
+  import { openPositions, positions } from '$lib/stores/positions';
+  import { fetchPositions } from '$lib/services/trading';
   import { blockchain } from '$lib/stores/blockchain';
   import { formatPrice, formatPriceChange, formatVolume } from '$lib/services/birdeye';
   import { markets, selectedMarket, currentMarket, loading, startUpdates, stopUpdates } from '$lib/stores/markets';
@@ -27,9 +29,18 @@
     selectedMarket.set(market.symbol);
   }
 
-  onMount(() => {
+  onMount(async () => {
     if (browser) {
       startUpdates();
+    }
+
+    if ($isAuthenticated && $walletAddress) {
+      try {
+        const list = await fetchPositions($walletAddress, 'open');
+        positions.setPositions(list);
+      } catch (e) {
+        console.error('Failed to fetch positions', e);
+      }
     }
   });
 
@@ -124,7 +135,11 @@
     
     <div class="space-y-6">
       <TradingPanel />
-      
+
+      <div class="card">
+        <PositionsTable />
+      </div>
+
       <div class="card space-y-3">
         <h3 class="text-sm font-semibold text-gray-400 flex items-center gap-2">
           <Shield class="w-4 h-4" />


### PR DESCRIPTION
## Summary
- add `setPositions` to positions store
- fetch positions from `/api/sdk/v1.0/positions/evm`
- display message when no positions exist
- always show the positions table card on the trade page

## Testing
- `pnpm check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a table displaying open trading positions, including details such as asset, size, entry price, current price, leverage, and profit/loss (PnL).
  - Added the ability to close positions directly from the positions table.
  - Transaction hash is now shown upon successfully opening a new position.

- **Improvements**
  - Positions are now fetched from an external API and updated in real-time based on the user's wallet address.
  - Enhanced error handling and loading states for opening and closing positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->