### PR TITLE
Load positions from API and show placeholder

### DIFF
--- a/src/lib/components/BirdeyeChart.svelte
+++ b/src/lib/components/BirdeyeChart.svelte
@@ -6,6 +6,7 @@
   import type { TokenModel } from '$lib/services/offers';
 
   export let height: number = 400;
+  export let symbol: string = '';
   
   let chartContainer: HTMLDivElement;
   let loading = true;

--- a/src/lib/services/positions.ts
+++ b/src/lib/services/positions.ts
@@ -1,0 +1,25 @@
+import { browser } from '$app/environment';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'https://ng-api.lavarave.wtf/api/sdk/v1.0';
+const API_KEY = import.meta.env.VITE_API_KEY || '';
+
+export async function fetchPositionsEvm(userAddress?: string, status: string = 'open') {
+  if (!browser) return [];
+
+  const params = new URLSearchParams();
+  if (userAddress) params.append('userAddress', userAddress);
+  if (status) params.append('status', status);
+
+  const res = await fetch(`${API_BASE_URL}/positions/evm?${params.toString()}`, {
+    headers: {
+      'x-api-key': API_KEY,
+      referer: window.location.origin,
+    }
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch positions');
+  }
+
+  return res.json();
+}

--- a/src/routes/trade/+page.svelte
+++ b/src/routes/trade/+page.svelte
@@ -4,7 +4,7 @@
   import MarketSelectorButton from '$lib/components/MarketSelectorButton.svelte';
   import PositionsTable from '$lib/components/PositionsTable.svelte';
   import { isAuthenticated } from '$lib/stores/auth';
-  import { openPositions } from '$lib/stores/positions';
+  import { openPositions, loadPositions } from '$lib/stores/positions';
   import { blockchain } from '$lib/stores/blockchain';
   import { formatPrice, formatPriceChange, formatVolume } from '$lib/services/birdeye';
   import { markets, selectedMarket, currentMarket, loading, startUpdates, stopUpdates } from '$lib/stores/markets';
@@ -39,6 +39,10 @@
       stopUpdates();
     }
   });
+
+  $: if ($isAuthenticated) {
+    loadPositions();
+  }
 
   $: priceChangeFormatted = formatPriceChange(priceChange24h);
   $: currentToken = $selectedMarket.split('-')[0];
@@ -126,11 +130,13 @@
     <div class="space-y-6">
       <TradingPanel />
 
-      {#if $openPositions.length > 0}
-        <div class="card">
+      <div class="card">
+        {#if $openPositions.length > 0}
           <PositionsTable />
-        </div>
-      {/if}
+        {:else}
+          <p class="text-center text-gray-400 py-4">No positions yet</p>
+        {/if}
+      </div>
 
       <div class="card space-y-3">
         <h3 class="text-sm font-semibold text-gray-400 flex items-center gap-2">


### PR DESCRIPTION
## Summary
- fetch positions from `/api/sdk/v1.0/positions/evm`
- add `loadPositions` helper and expose in store
- display positions card even when empty
- allow passing symbol prop to `BirdeyeChart`

## Testing
- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for loading and displaying open EVM positions associated with the user's wallet.
	- The positions card is now always visible on the trade page, showing either the positions table or a "No positions yet" message.
- **Enhancements**
	- Introduced a new property to the chart component for specifying a symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->