### PR TITLE
Implement real close position API

### DIFF
--- a/src/lib/services/trading.ts
+++ b/src/lib/services/trading.ts
@@ -1,8 +1,9 @@
-import type { Position } from '$lib/stores/positions';
-import type { SupportedBlockchain } from '$lib/stores/blockchain';
-import { getCurrentAccount } from '$lib/services/wallet';
-import { config } from '$lib/config/wagmi';
-import { sendTransaction, waitForTransactionReceipt } from '@wagmi/core';
+import type { Position } from "$lib/stores/positions";
+import type { SupportedBlockchain } from "$lib/stores/blockchain";
+import { getCurrentAccount } from "$lib/services/wallet";
+import { config } from "$lib/config/wagmi";
+import { sendTransaction, waitForTransactionReceipt } from "@wagmi/core";
+import { BSC_TOKEN_ADDRESSES } from "$lib/services/birdeye";
 
 export interface OpenPositionParams {
   blockchain: SupportedBlockchain;
@@ -34,16 +35,29 @@ interface TransactionBscModel {
   value?: string;
 }
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://ng-api.lavarave.wtf/api/sdk/v1.0';
-const API_KEY = import.meta.env.VITE_API_KEY || '';
+interface CloseBscPositionDto {
+  loanId: number;
+  userPubKey: string;
+  partnerFeeRecipient?: string;
+  quoteToken: string;
+  slippage?: number;
+}
 
-export async function openLongPosition(params: OpenPositionParams): Promise<string> {
+const API_URL =
+  import.meta.env.VITE_API_URL || "https://ng-api.lavarave.wtf/api/sdk/v1.0";
+const API_KEY = import.meta.env.VITE_API_KEY || "";
+
+export async function openLongPosition(
+  params: OpenPositionParams,
+): Promise<string> {
   const account = getCurrentAccount();
-  if (!account.address) throw new Error('Wallet not connected');
+  if (!account.address) throw new Error("Wallet not connected");
 
   const body: OpenBscPositionDto = {
     collateralAddress: params.collateralAddress,
-    margin: (BigInt(Math.round(params.collateral * 1000000)) * BigInt(1000000000000)).toString(),
+    margin: (
+      BigInt(Math.round(params.collateral * 1000000)) * BigInt(1000000000000)
+    ).toString(),
     leverage: params.leverage,
     quoteToken: params.quoteToken,
     userPubKey: account.address,
@@ -52,16 +66,16 @@ export async function openLongPosition(params: OpenPositionParams): Promise<stri
   };
 
   const res = await fetch(`${API_URL}/positions/bsc/open`, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': API_KEY,
+      "Content-Type": "application/json",
+      "x-api-key": API_KEY,
     },
     body: JSON.stringify(body),
   });
 
   if (!res.ok) {
-    throw new Error('Failed to get transaction data');
+    throw new Error("Failed to get transaction data");
   }
 
   const tx: TransactionBscModel = await res.json();
@@ -79,41 +93,77 @@ export async function openLongPosition(params: OpenPositionParams): Promise<stri
   return hash;
 }
 
-export async function closePosition(positionId: string): Promise<void> {
-  // Simulate network delay
-  await new Promise(resolve => setTimeout(resolve, 800));
-  
-  // In production, interact with smart contracts
-  // to close the position and return collateral + PnL
+export async function closePosition(positionId: string): Promise<string> {
+  const account = getCurrentAccount();
+  if (!account.address) throw new Error("Wallet not connected");
+
+  const body: CloseBscPositionDto = {
+    loanId: Number(positionId),
+    userPubKey: account.address,
+    quoteToken: BSC_TOKEN_ADDRESSES["BNB"],
+    slippage: 500,
+  };
+
+  const res = await fetch(`${API_URL}/positions/bsc/close`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": API_KEY,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to get transaction data");
+  }
+
+  const tx: TransactionBscModel = await res.json();
+
+  const hash = await sendTransaction(config, {
+    account: account.address,
+    to: tx.to as `0x${string}`,
+    data: tx.data as `0x${string}`,
+    gasPrice: tx.gasPrice ? BigInt(tx.gasPrice) : undefined,
+    value: tx.value ? BigInt(tx.value) : undefined,
+  });
+
+  await waitForTransactionReceipt(config, { hash });
+
+  return hash;
 }
 
-export async function updatePositionPrices(positions: Position[]): Promise<Position[]> {
+export async function updatePositionPrices(
+  positions: Position[],
+): Promise<Position[]> {
   // Mock price updates
-  return positions.map(pos => {
-    if (pos.status !== 'open') return pos;
-    
+  return positions.map((pos) => {
+    if (pos.status !== "open") return pos;
+
     // Simulate price movement (-2% to +2%)
     const priceChange = (Math.random() - 0.5) * 0.04;
     const newPrice = pos.currentPrice * (1 + priceChange);
-    
+
     const priceDiff = newPrice - pos.entryPrice;
     const pnl = (priceDiff / pos.entryPrice) * pos.size;
     const pnlPercentage = (pnl / pos.collateral) * 100;
-    
+
     return {
       ...pos,
       currentPrice: newPrice,
       pnl,
-      pnlPercentage
+      pnlPercentage,
     };
   });
 }
 
-function calculateLiquidationPrice(entryPrice: number, leverage: number): number {
+function calculateLiquidationPrice(
+  entryPrice: number,
+  leverage: number,
+): number {
   // Simplified liquidation price calculation
   const maintenanceMarginRate = 0.005; // 0.5%
   const initialMarginRate = 1 / leverage;
-  
+
   // For long positions
   return entryPrice * (1 - initialMarginRate + maintenanceMarginRate);
 }


### PR DESCRIPTION
## Summary
- implement transaction call for closing positions via /positions/bsc/close
- align trading service with swagger CloseBscPositionDto

## Testing
- `npm run check` *(fails: svelte-check found 1 error)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Closing positions on BSC is now fully supported, including API interaction and blockchain transaction handling.

- **Bug Fixes**
  - Improved price updates for open positions, ensuring more accurate PnL calculations.

- **Style**
  - Minor formatting and style improvements for enhanced code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->