### PR TITLE
Implement auto-refresh for positions and UI fixes

### DIFF
--- a/src/lib/components/PositionCard.svelte
+++ b/src/lib/components/PositionCard.svelte
@@ -2,7 +2,8 @@
   import type { Position } from '$lib/stores/positions';
   import { positions } from '$lib/stores/positions';
   import { closePosition } from '$lib/services/trading';
-  import { TrendingUp, X, Loader2 } from 'lucide-svelte';
+  import { formatNumber } from '$lib/utils/formatters';
+  import { TrendingUp, Loader2 } from 'lucide-svelte';
   
   export let position: Position;
   
@@ -48,13 +49,13 @@
     <button
       on:click={handleClose}
       disabled={closing}
-      class="p-2 hover:bg-white/5 rounded-lg transition-colors"
-      title="Close position"
+      class="btn-secondary text-xs"
     >
       {#if closing}
         <Loader2 class="w-4 h-4 animate-spin" />
+        <span class="sr-only">Closing...</span>
       {:else}
-        <X class="w-4 h-4 text-gray-400" />
+        Close
       {/if}
     </button>
   </div>
@@ -62,22 +63,22 @@
   <div class="grid grid-cols-2 gap-4 mb-4">
     <div>
       <p class="text-xs text-gray-400 mb-1">Entry Price</p>
-      <p class="font-mono font-medium">${position.entryPrice.toFixed(2)}</p>
+      <p class="font-mono font-medium">${formatNumber(position.entryPrice, 2)}</p>
     </div>
     
     <div>
       <p class="text-xs text-gray-400 mb-1">Current Price</p>
-      <p class="font-mono font-medium">${position.currentPrice.toFixed(2)}</p>
+      <p class="font-mono font-medium">${formatNumber(position.currentPrice, 2)}</p>
     </div>
     
     <div>
       <p class="text-xs text-gray-400 mb-1">Position Size</p>
-      <p class="font-mono font-medium">{position.size.toFixed(4)}</p>
+      <p class="font-mono font-medium">{formatNumber(position.size, 4)}</p>
     </div>
     
     <div>
       <p class="text-xs text-gray-400 mb-1">Collateral</p>
-      <p class="font-mono font-medium">{position.collateral.toFixed(4)}</p>
+      <p class="font-mono font-medium">{formatNumber(position.collateral, 4)}</p>
     </div>
   </div>
   
@@ -86,21 +87,21 @@
       <div>
         <p class="text-xs text-gray-400 mb-1">PnL</p>
         <p class="font-mono text-lg font-semibold {position.pnl >= 0 ? 'text-green-400' : 'text-red-400'}">
-          {position.pnl >= 0 ? '+' : ''}{position.pnl.toFixed(4)}
+          {position.pnl >= 0 ? '+' : ''}{formatNumber(position.pnl, 4)}
         </p>
       </div>
       
       <div class="text-right">
         <p class="text-xs text-gray-400 mb-1">ROI</p>
         <p class="font-mono text-lg font-semibold {position.pnlPercentage >= 0 ? 'text-green-400' : 'text-red-400'}">
-          {position.pnlPercentage >= 0 ? '+' : ''}{position.pnlPercentage.toFixed(2)}%
+          {position.pnlPercentage >= 0 ? '+' : ''}{formatNumber(position.pnlPercentage, 2)}%
         </p>
       </div>
     </div>
     
     <div class="mt-3 p-2 bg-orange-500/10 border border-orange-500/20 rounded-lg">
       <p class="text-xs text-orange-400">
-        Liquidation: ${position.liquidationPrice.toFixed(2)}
+        Liquidation: ${formatNumber(position.liquidationPrice, 2)}
       </p>
     </div>
   </div>

--- a/src/lib/components/PositionsTable.svelte
+++ b/src/lib/components/PositionsTable.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { positions, openPositions } from '$lib/stores/positions';
   import { closePosition } from '$lib/services/trading';
+  import { selectedMarket } from '$lib/stores/markets';
+  import { formatNumber } from '$lib/utils/formatters';
 
   let closing: Record<string, boolean> = {};
+
+  $: filtered = $openPositions.filter(p => p.asset === $selectedMarket);
 
   async function handleClose(id: string) {
     closing[id] = true;
@@ -30,15 +34,15 @@
     </tr>
   </thead>
   <tbody>
-    {#each $openPositions as p (p.id)}
+    {#each filtered as p (p.id)}
       <tr class="border-b border-white/10">
         <td class="px-3 py-2 font-mono">{p.asset}</td>
-        <td class="px-3 py-2 text-right font-mono">{p.size.toFixed(4)}</td>
-        <td class="px-3 py-2 text-right font-mono">${p.entryPrice.toFixed(2)}</td>
-        <td class="px-3 py-2 text-right font-mono">${p.currentPrice.toFixed(2)}</td>
+        <td class="px-3 py-2 text-right font-mono">{formatNumber(p.size, 4)}</td>
+        <td class="px-3 py-2 text-right font-mono">${formatNumber(p.entryPrice, 2)}</td>
+        <td class="px-3 py-2 text-right font-mono">${formatNumber(p.currentPrice, 2)}</td>
         <td class="px-3 py-2 text-right font-mono">{p.leverage}x</td>
         <td class="px-3 py-2 text-right font-mono {p.pnl >= 0 ? 'text-green-400' : 'text-red-400'}">
-          {p.pnl >= 0 ? '+' : ''}{p.pnl.toFixed(2)}
+          {p.pnl >= 0 ? '+' : ''}{formatNumber(p.pnl, 2)}
         </td>
         <td class="px-3 py-2 text-right">
           <button class="btn-secondary text-xs" disabled={closing[p.id]} on:click={() => handleClose(p.id)}>

--- a/src/lib/stores/positions.ts
+++ b/src/lib/stores/positions.ts
@@ -1,4 +1,5 @@
 import { writable, derived, get } from 'svelte/store';
+import { browser } from '$app/environment';
 import type { SupportedBlockchain } from './blockchain';
 import { fetchPositionsEvm } from '$lib/services/positions';
 import { walletAddress } from './auth';
@@ -92,6 +93,8 @@ export const totalCollateral = derived(
   $openPositions => $openPositions.reduce((sum, p) => sum + p.collateral, 0)
 );
 
+let updateInterval: NodeJS.Timeout | null = null;
+
 
 export async function loadPositions(): Promise<void> {
   const address = get(walletAddress);
@@ -126,5 +129,18 @@ export async function loadPositions(): Promise<void> {
     positions.setError('Failed to load positions');
   } finally {
     positions.setLoading(false);
+  }
+}
+
+export function startPositionsUpdates(interval = 10000) {
+  if (!browser || updateInterval) return;
+  loadPositions();
+  updateInterval = setInterval(loadPositions, interval);
+}
+
+export function stopPositionsUpdates() {
+  if (updateInterval) {
+    clearInterval(updateInterval);
+    updateInterval = null;
   }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,15 +1,28 @@
 <script lang="ts">
   import '../app.css';
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import { restoreWalletSession } from '$lib/services/wallet';
+  import { isAuthenticated } from '$lib/stores/auth';
+  import { startPositionsUpdates, stopPositionsUpdates } from '$lib/stores/positions';
   import Nav from '$lib/components/Nav.svelte';
 
   onMount(async () => {
     try {
       await restoreWalletSession();
+      if ($isAuthenticated) startPositionsUpdates();
     } catch (e) {
       console.warn('Failed to restore wallet session:', e);
     }
+  });
+
+  $: if ($isAuthenticated) {
+    startPositionsUpdates();
+  } else {
+    stopPositionsUpdates();
+  }
+
+  onDestroy(() => {
+    stopPositionsUpdates();
   });
 </script>
 

--- a/src/routes/positions/+page.svelte
+++ b/src/routes/positions/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { isAuthenticated } from '$lib/stores/auth';
   import { openPositions, totalPnL, totalCollateral } from '$lib/stores/positions';
+  import { formatNumber } from '$lib/utils/formatters';
   import PositionCard from '$lib/components/PositionCard.svelte';
   import { Activity, TrendingUp, DollarSign, AlertCircle } from 'lucide-svelte';
   
@@ -37,7 +38,7 @@
           <p class="text-sm text-gray-400">Total Collateral</p>
           <DollarSign class="w-4 h-4 text-purple-400" />
         </div>
-        <p class="text-2xl font-mono font-semibold">{$totalCollateral.toFixed(4)}</p>
+        <p class="text-2xl font-mono font-semibold">{formatNumber($totalCollateral, 4)}</p>
       </div>
       
       <div class="card">
@@ -46,7 +47,7 @@
           <TrendingUp class="w-4 h-4 {$totalPnL >= 0 ? 'text-green-400' : 'text-red-400'}" />
         </div>
         <p class="text-2xl font-mono font-semibold {$totalPnL >= 0 ? 'text-green-400' : 'text-red-400'}">
-          {$totalPnL >= 0 ? '+' : ''}{$totalPnL.toFixed(4)}
+          {$totalPnL >= 0 ? '+' : ''}{formatNumber($totalPnL, 4)}
         </p>
       </div>
       
@@ -55,7 +56,7 @@
           <p class="text-sm text-gray-400">Total Value</p>
           <Activity class="w-4 h-4 text-orange-400" />
         </div>
-        <p class="text-2xl font-mono font-semibold">{totalValue.toFixed(4)}</p>
+        <p class="text-2xl font-mono font-semibold">{formatNumber(totalValue, 4)}</p>
       </div>
       
       <div class="card">
@@ -64,7 +65,7 @@
           <AlertCircle class="w-4 h-4 {totalReturn >= 0 ? 'text-green-400' : 'text-red-400'}" />
         </div>
         <p class="text-2xl font-mono font-semibold {totalReturn >= 0 ? 'text-green-400' : 'text-red-400'}">
-          {totalReturn >= 0 ? '+' : ''}{totalReturn.toFixed(2)}%
+          {totalReturn >= 0 ? '+' : ''}{formatNumber(totalReturn, 2)}%
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refresh positions globally every 10 seconds
- start/stop refresh from layout depending on wallet connection
- filter trade page positions table by selected market
- improve close button and formatting in position card
- fix numbers display on positions page

## Testing
- `npm run check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Positions data now updates automatically at regular intervals while you are authenticated, ensuring information stays current without manual refresh.
- **Improvements**
	- All numeric values across positions-related views are now consistently formatted for better readability.
	- The positions table only displays positions relevant to the currently selected market.
	- The close button in position cards is now clearer and more accessible, with improved feedback when closing a position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->