### PR TITLE
Use offer data for trade info

### DIFF
--- a/src/lib/services/offers.ts
+++ b/src/lib/services/offers.ts
@@ -49,6 +49,10 @@ export interface MarketData {
   maxLeverage: number;
   apr: number;
   availableForOpen: string;
+  maxBorrow?: string;
+  maxOpenPerTrade?: string;
+  maxExposure?: string;
+  currentExposure?: string;
   collateralToken?: TokenModel;
   quoteToken: TokenModel | string;
   priceVsQuote: string;
@@ -128,6 +132,10 @@ export function transformOfferToMarket(offer: OfferEvmModel): MarketData {
     maxLeverage: offer.maxLeverage,
     apr: offer.apr,
     availableForOpen: offer.availableForOpen,
+    maxBorrow: offer.maxBorrow,
+    maxOpenPerTrade: offer.maxOpenPerTrade,
+    maxExposure: offer.maxExposure,
+    currentExposure: offer.currentExposure,
     collateralToken: offer.collateralToken,
     quoteToken: offer.quoteToken,
     priceVsQuote: offer.priceVsQuote,
@@ -159,6 +167,10 @@ export function getMockMarketData(): MarketData[] {
       maxLeverage: 10,
       apr: 12.5,
       availableForOpen: '1000000000000',
+      maxBorrow: '500000000000',
+      maxOpenPerTrade: '100000000000',
+      maxExposure: '2000000000000',
+      currentExposure: '800000000000',
       quoteToken: 'BNB',
       priceVsQuote: '1.0000',
     },
@@ -174,6 +186,10 @@ export function getMockMarketData(): MarketData[] {
       maxLeverage: 20,
       apr: 8.2,
       availableForOpen: '2000000000000',
+      maxBorrow: '1000000000000',
+      maxOpenPerTrade: '200000000000',
+      maxExposure: '4000000000000',
+      currentExposure: '1500000000000',
       quoteToken: 'BNB',
       priceVsQuote: '1.0001',
     },
@@ -189,6 +205,10 @@ export function getMockMarketData(): MarketData[] {
       maxLeverage: 20,
       apr: 7.8,
       availableForOpen: '1800000000000',
+      maxBorrow: '800000000000',
+      maxOpenPerTrade: '150000000000',
+      maxExposure: '3500000000000',
+      currentExposure: '1200000000000',
       quoteToken: 'BNB',
       priceVsQuote: '0.9999',
     },
@@ -204,8 +224,12 @@ export function getMockMarketData(): MarketData[] {
       maxLeverage: 15,
       apr: 15.3,
       availableForOpen: '500000000000',
+      maxBorrow: '250000000000',
+      maxOpenPerTrade: '50000000000',
+      maxExposure: '1000000000000',
+      currentExposure: '200000000000',
       quoteToken: 'BNB',
       priceVsQuote: '1.0000',
     },
   ];
-} 
+}

--- a/src/routes/trade/+page.svelte
+++ b/src/routes/trade/+page.svelte
@@ -46,6 +46,10 @@
 
   $: priceChangeFormatted = formatPriceChange(priceChange24h);
   $: currentToken = $selectedMarket.split('-')[0];
+  $: maxLeverageDisplay = $currentMarket ? `${$currentMarket.maxLeverage}x` : '--';
+  $: interestPerDay = $currentMarket ? `${($currentMarket.apr / 365).toFixed(2)}%` : '--';
+  $: openInterest = $currentMarket ? formatVolume(Number($currentMarket.currentExposure ?? $currentMarket.availableForOpen)) : '--';
+  $: minPosition = $currentMarket?.maxOpenPerTrade ? `${Number($currentMarket.maxOpenPerTrade).toLocaleString()} ${currentToken}` : '--';
 </script>
 
 <div class="max-w-6xl mx-auto">
@@ -103,15 +107,15 @@
           <div class="space-y-2">
             <div class="flex justify-between">
               <span class="text-gray-400">Max Leverage</span>
-              <span class="font-mono">100x</span>
+              <span class="font-mono">{maxLeverageDisplay}</span>
             </div>
             <div class="flex justify-between">
-              <span class="text-gray-400">Funding Rate</span>
-              <span class="font-mono text-green-400">+0.01%</span>
+              <span class="text-gray-400">Interest / Day</span>
+              <span class="font-mono text-green-400">{interestPerDay}</span>
             </div>
             <div class="flex justify-between">
               <span class="text-gray-400">Open Interest</span>
-              <span class="font-mono">$1.2B</span>
+              <span class="font-mono">{openInterest}</span>
             </div>
           </div>
           
@@ -126,7 +130,7 @@
             </div>
             <div class="flex justify-between">
               <span class="text-gray-400">Min Position</span>
-              <span class="font-mono">0.001 {currentToken}</span>
+              <span class="font-mono">{minPosition}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- extend `MarketData` with exposure and limit fields
- propagate offer fields in `transformOfferToMarket`
- update mock markets with new data
- show dynamic trade info on trade page
- compute interest per day from APR

## Testing
- `npm run check` *(fails: Property 'loanId' is missing in type 'Position')*