### PR TITLE
Add BNB collateral indicator

### DIFF
--- a/src/routes/positions/+page.svelte
+++ b/src/routes/positions/+page.svelte
@@ -24,7 +24,10 @@
 
   $: positionsList = showClosed ? $closedPositions : $openPositions;
 
-  $: totalValue = $totalCollateral + $totalPnL;
+  $: totalEquity = $openPositions.reduce(
+    (sum, p) => sum + p.collateral * p.currentPrice,
+    0
+  );
   $: totalReturn = $totalCollateral > 0 ? ($totalPnL / $totalCollateral) * 100 : 0;
 </script>
 
@@ -54,10 +57,10 @@
     <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
       <div class="card">
         <div class="flex items-center justify-between mb-2">
-          <p class="text-sm text-gray-400">Total Collateral</p>
+          <p class="text-sm text-gray-400">Total Collateral (BNB)</p>
           <DollarSign class="w-4 h-4 text-purple-400" />
         </div>
-        <p class="text-2xl font-mono font-semibold">{formatNumber($totalCollateral, 4)}</p>
+        <p class="text-2xl font-mono font-semibold">{formatNumber($totalCollateral, 4)} BNB</p>
       </div>
       
       <div class="card">
@@ -72,10 +75,10 @@
       
       <div class="card">
         <div class="flex items-center justify-between mb-2">
-          <p class="text-sm text-gray-400">Total Value</p>
+          <p class="text-sm text-gray-400">Total Equity</p>
           <Activity class="w-4 h-4 text-orange-400" />
         </div>
-        <p class="text-2xl font-mono font-semibold">{formatNumber(totalValue, 4)}</p>
+        <p class="text-2xl font-mono font-semibold">{formatNumber(totalEquity, 4)}</p>
       </div>
       
       <div class="card">


### PR DESCRIPTION
## Summary
- show total collateral in BNB and rename total value widget to **Total Equity** on positions page
- compute total equity using each position's collateral and current price

## Testing
- `npm run check`
