### PR TITLE
Fix positions refresh

### DIFF
--- a/src/lib/stores/positions.ts
+++ b/src/lib/stores/positions.ts
@@ -102,6 +102,7 @@ export const totalCollateral = derived(
 );
 
 let updateInterval: NodeJS.Timeout | null = null;
+let updateStatus: 'open' | 'closed' = 'open';
 
 
 export async function loadPositions(status: 'open' | 'closed' = 'open'): Promise<void> {
@@ -141,10 +142,12 @@ export async function loadPositions(status: 'open' | 'closed' = 'open'): Promise
   }
 }
 
-export function startPositionsUpdates(interval = 10000) {
-  if (!browser || updateInterval) return;
-  loadPositions();
-  updateInterval = setInterval(loadPositions, interval);
+export function startPositionsUpdates(status: 'open' | 'closed' = 'open', interval = 10000) {
+  if (!browser) return;
+  stopPositionsUpdates();
+  updateStatus = status;
+  loadPositions(status);
+  updateInterval = setInterval(() => loadPositions(updateStatus), interval);
 }
 
 export function stopPositionsUpdates() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,14 +9,14 @@
   onMount(async () => {
     try {
       await restoreWalletSession();
-      if ($isAuthenticated) startPositionsUpdates();
+      if ($isAuthenticated) startPositionsUpdates('open');
     } catch (e) {
       console.warn('Failed to restore wallet session:', e);
     }
   });
 
   $: if ($isAuthenticated) {
-    startPositionsUpdates();
+    startPositionsUpdates('open');
   } else {
     stopPositionsUpdates();
   }

--- a/src/routes/positions/+page.svelte
+++ b/src/routes/positions/+page.svelte
@@ -5,9 +5,7 @@
     closedPositions,
     totalPnL,
     totalCollateral,
-    loadPositions,
-    startPositionsUpdates,
-    stopPositionsUpdates
+    startPositionsUpdates
   } from '$lib/stores/positions';
   import { formatNumber } from '$lib/utils/formatters';
   import PositionCard from '$lib/components/PositionCard.svelte';
@@ -17,9 +15,7 @@
 
   function toggleView() {
     showClosed = !showClosed;
-    stopPositionsUpdates();
-    loadPositions(showClosed ? 'closed' : 'open');
-    if (!showClosed) startPositionsUpdates();
+    startPositionsUpdates(showClosed ? 'closed' : 'open');
   }
 
   $: positionsList = showClosed ? $closedPositions : $openPositions;


### PR DESCRIPTION
## Summary
- ensure closed positions update by allowing startPositionsUpdates to handle statuses
- pass status to startPositionsUpdates from layout and positions page

## Testing
- `pnpm check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved control over position updates, allowing users to toggle between viewing and updating "open" or "closed" positions more seamlessly.

- **Refactor**
  - Streamlined the logic for updating position views, resulting in a more consistent and efficient experience when switching between "open" and "closed" positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->